### PR TITLE
Resolve a deprecation warning in Ruby 2.7+

### DIFF
--- a/lib/csv-safe.rb
+++ b/lib/csv-safe.rb
@@ -4,10 +4,10 @@ require 'csv'
 # Override << to sanitize incoming rows
 # Override initialize to add a converter that will sanitize fields being read
 class CSVSafe < CSV
-  def initialize(data, options = {})
-    options[:converters] = [] if options[:converters].nil?
-    options[:converters] << lambda(&method(:sanitize_field))
-    super
+  def initialize(data, converters: nil, **options)
+    updated_converters = converters || []
+    updated_converters << lambda(&method(:sanitize_field))
+    super(data, **options.merge(converters: updated_converters))
   end
 
   def <<(row)


### PR DESCRIPTION
Ruby 2.7 makes some changes in how splatting keyword args is handled. That, along with a change in the CSV initialize signature (from a single options object to explicit, separate keyword args) causes some warnings from this gem (which will become actual errors in Ruby 3.0).

```
/home/mpd/git-sources/csv-safe/lib/csv-safe.rb:10: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/mpd/.rvm/rubies/ruby-2.7.1/lib/ruby/2.7.0/csv.rb:921: warning: The called method `initialize' is defined here
```

I'm not sure how you want to handle this, since this may break support for older Ruby versions, but here is the fix for anyone finding it in the future. The test suite remains green with this change.