### PR TITLE
Zvory/ruby 3.0 upgrade (ping me if you want this merged)

### DIFF
--- a/csv-safe.gemspec
+++ b/csv-safe.gemspec
@@ -4,7 +4,7 @@ require 'csv-safe'
 
 Gem::Specification.new do |spec|
   spec.name          = 'csv-safe'
-  spec.version       = '1.2.0'
+  spec.version       = '2.0.0'
   spec.authors       = ['Alex Zvorygin']
   spec.email         = ['grafetu@gmail.com']
 
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+
+  spec.required_ruby_version = '>= 3.0.0'
 
   spec.add_development_dependency 'bundler', '>= 2.1.4'
   spec.add_development_dependency "rake", ">= 12.3.3"

--- a/csv-safe.gemspec
+++ b/csv-safe.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'csv-safe'
   spec.version       = '1.2.0'
   spec.authors       = ['Alex Zvorygin']
-  spec.email         = ['alexander.zvorygin@influitive.com']
+  spec.email         = ['grafetu@gmail.com']
 
   spec.summary       = 'Decorate ruby CSV library to sanitize ' \
     'output CSV against CSV injection attacks.'
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'bundler', '>= 2.1.4'
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/lib/csv-safe.rb
+++ b/lib/csv-safe.rb
@@ -4,10 +4,10 @@ require 'csv'
 # Override << to sanitize incoming rows
 # Override initialize to add a converter that will sanitize fields being read
 class CSVSafe < CSV
-  def initialize(data, options = {})
-    options[:converters] = [] if options[:converters].nil?
-    options[:converters] << lambda(&method(:sanitize_field))
-    super
+  def initialize(data, converters: nil, **options)
+    updated_converters = converters || []
+    updated_converters << lambda(&method(:sanitize_field))
+    super(data, **options.merge(converters: updated_converters))
   end
 
   def <<(row)


### PR DESCRIPTION
Ruby 3.0 will cause some errors in this gem (#1).

I am using https://github.com/xxx 's changes in the above PR here to account for that, along with some other modifications but this is a breaking change. 

The gemspec file requires ruby 3.0 for this reason, even though at time of writing 3.0 is not out yet. It appears I cannot release this update until Ruby 3.0 is out, so ping me when that happens so I can merge this and release a new version of the gem. 
