### PR TITLE
2.0: Resolve Ruby 2.7 deprecation warnings, lint, update deps, add tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,3 @@ group :development, :test do
 end
 
 gem 'simplecov', require: false, group: :test
-

--- a/csv-safe.gemspec
+++ b/csv-safe.gemspec
@@ -4,9 +4,9 @@ require 'csv-safe'
 
 Gem::Specification.new do |spec|
   spec.name          = 'csv-safe'
-  spec.version       = '1.2.0'
+  spec.version       = '2.0.0'
   spec.authors       = ['Alex Zvorygin']
-  spec.email         = ['alexander.zvorygin@influitive.com']
+  spec.email         = ['grafetu@gmail.com']
 
   spec.summary       = 'Decorate ruby CSV library to sanitize ' \
     'output CSV against CSV injection attacks.'
@@ -19,7 +19,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.required_ruby_version = '>= 2.7.0'
+
+  spec.add_development_dependency 'bundler', '>= 2.1.4'
+  spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/lib/csv-safe.rb
+++ b/lib/csv-safe.rb
@@ -4,17 +4,17 @@ require 'csv'
 # Override << to sanitize incoming rows
 # Override initialize to add a converter that will sanitize fields being read
 class CSVSafe < CSV
-  def initialize(data, options = {})
+  def initialize(data, **options)
     options[:converters] = [] if options[:converters].nil?
     options[:converters] << lambda(&method(:sanitize_field))
-    super
+    super(data, **options)
   end
 
   def <<(row)
     super(sanitize_row(row))
   end
-  alias_method :add_row, :<<
-  alias_method :puts,    :<<
+  alias add_row <<
+  alias puts <<
 
   private
 


### PR DESCRIPTION
Ruby 3.0 will cause some errors in this gem
(https://github.com/zvory/csv-safe/pull/1).

I am using some of xxx's changes here to account for that. This change
should not be breaking, but I'm bumping a major version anyway.

Other changes:
 - added some tests to make sure options parameter and converters were being passed correctly
 - version 2 of this gem is gated behind ruby 2.7
 - updated some development dependencies
 - ran rubocop
 - fixed some misplaced block statements in the spec
