### PR TITLE
[CSV-SAFE] Update 2.0.0 Gem version to allow ruby >= 2.7

### DIFF
--- a/csv-safe.gemspec
+++ b/csv-safe.gemspec
@@ -4,7 +4,7 @@ require 'csv-safe'
 
 Gem::Specification.new do |spec|
   spec.name          = 'csv-safe'
-  spec.version       = '2.0.0'
+  spec.version       = '2.1.0'
   spec.authors       = ['Alex Zvorygin']
   spec.email         = ['grafetu@gmail.com']
 
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 2.7.0'
 
   spec.add_development_dependency 'bundler', '>= 2.1.4'
   spec.add_development_dependency "rake", ">= 12.3.3"


### PR DESCRIPTION
___Before___

The last update prevents the Gem usage if the Ruby version < 3.0.0.

___After___

The gem could be used with Ruby >= 2.7.0