### PR TITLE
Allow to use the gem with all currently supported ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.3
+  - 2.6.9
+  - 2.7.5
+  - 3.0.3
 before_install: gem install bundler -v 1.16.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
   - 2.6.9
   - 2.7.5
   - 3.0.3
-before_install: gem install bundler -v 1.16.1
+before_install: gem install bundler -v 2.1.4

--- a/csv-safe.gemspec
+++ b/csv-safe.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 2.6.0'
 
   spec.add_development_dependency 'bundler', '>= 2.1.4'
   spec.add_development_dependency "rake", ">= 12.3.3"


### PR DESCRIPTION
I have also taken the opportunity to fix the configuration for travis-ci and make it test against
- ruby 2.6
- ruby 2.7
- ruby 3.0
- ruby 3.1

~probably next week we will need to adjust this to include ruby 3.1, as well.~
