### PR TITLE
Prefix starting with '%'

### DIFF
--- a/csv-safe.gemspec
+++ b/csv-safe.gemspec
@@ -4,7 +4,7 @@ require 'csv-safe'
 
 Gem::Specification.new do |spec|
   spec.name          = 'csv-safe'
-  spec.version       = '2.1.0'
+  spec.version       = '3.0.0'
   spec.authors       = ['Alex Zvorygin']
   spec.email         = ['grafetu@gmail.com']
 

--- a/lib/csv-safe.rb
+++ b/lib/csv-safe.rb
@@ -21,7 +21,7 @@ class CSVSafe < CSV
   # TODO: performance test if i'm adding
   # too many method calls to hot code
   def starts_with_special_character?(str)
-    %w[- = + @].include?(str[0])
+    %w[- = + @ % |].include?(str[0])
   end
 
   def prefix(field)

--- a/spec/csv_safe_spec.rb
+++ b/spec/csv_safe_spec.rb
@@ -59,6 +59,18 @@ RSpec.describe CSVSafe do
       it { should eq expected }
     end
 
+    context 'with a field that starts with a %' do
+      let(:field) { "%0A-2+3+cmd|' /C calc'!'E2'" }
+      let(:expected) { "'%0A-2+3+cmd|' /C calc'!'E2'" }
+      it { should eq expected }
+    end
+
+    context 'with a field that starts with a %' do
+      let(:field) { "|-2+3+cmd|' /C calc'!'E2'" }
+      let(:expected) { "'|-2+3+cmd|' /C calc'!'E2'" }
+      it { should eq expected }
+    end
+
     context 'with a field that is a date' do
       let(:field) { Time.now }
       it { should eq field }
@@ -221,6 +233,17 @@ RSpec.describe CSVSafe do
 
           let(:expected) do
             ["'+-2+3+cmd|' /C calc'!'E2'"]
+          end
+          it { should eq arr_to_line(expected) }
+        end
+
+        context 'because it starts with a %' do
+          let(:row) do
+            ["%0A-2+3+cmd|' /C calc'!'E2'"]
+          end
+
+          let(:expected) do
+            ["'%0A-2+3+cmd|' /C calc'!'E2'"]
           end
           it { should eq arr_to_line(expected) }
         end


### PR DESCRIPTION
As reported on #7, the sanitization is missing on '%' this adds it to the list of special characters that need sanitization