### PR TITLE
Use `String#start_with?` to detect leading special character

### DIFF
--- a/lib/csv-safe.rb
+++ b/lib/csv-safe.rb
@@ -18,10 +18,8 @@ class CSVSafe < CSV
 
   private
 
-  # TODO: performance test if i'm adding
-  # too many method calls to hot code
   def starts_with_special_character?(str)
-    %w[- = + @ % |].include?(str[0])
+    str.start_with?('-', '=', '+', '@', '%', '|')
   end
 
   def prefix(field)


### PR DESCRIPTION
This change uses Ruby's built-in `String#start_with?`, which is implemented entirely in C (in MRI, anyway) and faster than the current implementation. `String#start_with?` is available in all versions of Ruby that CSVSafe supports.

Benchmarks show a 4.1% speed improvement in line generation.

```ruby
require "benchmark"

Benchmark.bmbm do |bm_out|
	bm_out.report { 5_000_000.times { CSVSafe.generate_line(["|yes", "no"]) } }
end
```

Legacy code:

```
       user     system      total        real
  92.012501   0.246394  92.258895 ( 92.277018)
```

This branch:

```
       user     system      total        real
  88.270658   0.248487  88.519145 ( 88.541700)
```

The `#starts_with_special_character?` method itself is between 20.9% and 28.2% faster, using a similar benchmark.

I was unable to find any cases where this branch is slower.