### PR TITLE
Add frozen_string_literal comment

### DIFF
--- a/lib/csv-safe.rb
+++ b/lib/csv-safe.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'csv'
 
 # Decorate the built in CSV library


### PR DESCRIPTION
This change adds `frozen_string_literal: true`. Frozen strings are allocated once at parse-time and reused. This saves a substantial number of memory allocations and String instantiations. This magic comment is safe to use in all versions of Ruby.

Benchmarking using the same snippet as in https://github.com/zvory/csv-safe/pull/12 shows a 1.2% speedup in line generation. Note that these benchmarks were performed with https://github.com/zvory/csv-safe/pull/12 applied.

```ruby
require "benchmark"

Benchmark.bmbm do |bm_out|
	bm_out.report { 5_000_000.times { CSVSafe.generate_line(["|yes", "no"]) } }
end
```

Legacy:

```
       user     system      total        real
  89.457235   0.255369  89.712604 ( 89.747471)
```

This branch:

```
       user     system      total        real
  88.287842   0.264821  88.552663 ( 88.604517)
```

The `#starts_with_special_character?` method itself is about 37% faster, using a similar benchmark.