### PR TITLE
Add `csv` as a dependency

### DIFF
--- a/csv-safe.gemspec
+++ b/csv-safe.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.6.0'
 
+  spec.add_dependency 'csv', '~> 3.0'
+
   spec.add_development_dependency 'bundler', '>= 2.1.4'
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
In Ruby 3.4, CSV-related functionality will be removed from the standard library, meaning csv-safe will stop working, as it assumes that it'll be available from there.

The functionality previously in the standard library has been extracted into the `csv` gem. To that end, this adds the `csv` gem as a dependency to ensure things keep working as expected in the future.

Additionally, this silences a warning that is produced in Ruby 3.3.1, as detailed in zvory/csv-safe#19.