### PR TITLE
Exclude phone numbers starting with + sign from sanitisation

### DIFF
--- a/lib/csv-safe.rb
+++ b/lib/csv-safe.rb
@@ -21,6 +21,8 @@ class CSVSafe < CSV
   private
 
   def starts_with_special_character?(str)
+    return false if str.start_with?('+') && phone_number?(str)
+
     str.start_with?("-", "=", "+", "@", "%", "|", "\r", "\t")
   end
 
@@ -57,5 +59,9 @@ class CSVSafe < CSV
     else
       row.map { |field| sanitize_field(field) }
     end
+  end
+
+  def phone_number?(value)
+    value.match?(/^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{2,3}?[-\s\.]?[0-9]{2,3}[-\s\.]?[0-9]{2,4}$/)
   end
 end

--- a/spec/csv_safe_spec.rb
+++ b/spec/csv_safe_spec.rb
@@ -91,6 +91,14 @@ RSpec.describe CSVSafe do
       end
     end
 
+    context 'with a field that is a phone number' do
+      let(:field) { '+353 89 999 9999' }
+      it { should eq field }
+      it 'should not error' do
+        expect { subject }.to_not raise_error
+      end
+    end
+
     # TODO: this file is too big?
 
     context 'with a field that is a non-String' do
@@ -197,6 +205,16 @@ RSpec.describe CSVSafe do
       context 'with a row that contains dates' do
         let(:row) do
           ['hi mom', Time.now]
+        end
+        it { should eq arr_to_line(row) }
+        it 'should not raise an error' do
+          expect { subject }.to_not raise_error
+        end
+      end
+
+      context 'with a row that contains phone numbers' do
+        let(:row) do
+          ['+353 89 999 9999', '+353899999999', '+353-999-999-999', '+353 899 99 99']
         end
         it { should eq arr_to_line(row) }
         it 'should not raise an error' do


### PR DESCRIPTION
This small change excludes the phone number starts with `+` sign from sanitisation. 

#### Changes: 
* Added `phone_number?` method that compares input with regexp to determine if input is a phone number → may require some future improvements 
* Added conditional return in `starts_with_special_character` method if given input starts with `+` and is a phone number
* Added tests