### PR TITLE
Refactor implementation to use accessor for headers, avoiding crash

### DIFF
--- a/lib/csv-safe.rb
+++ b/lib/csv-safe.rb
@@ -51,7 +51,7 @@ class CSVSafe < CSV
   def sanitize_row(row)
     return row.fields.map { |field| sanitize_field(field) } if row.is_a?(self.class::Row)
 
-    return @headers.map { |header| sanitize_field(row[header]) } if row.is_a?(Hash) && !@headers.nil?
+    return headers.map { |header| sanitize_field(row[header]) } if row.is_a?(Hash) && !headers.nil?
 
     row.map { |field| sanitize_field(field) }
   end

--- a/lib/csv-safe.rb
+++ b/lib/csv-safe.rb
@@ -53,7 +53,7 @@ class CSVSafe < CSV
     when self.class::Row
       then row.fields.map { |field| sanitize_field(field) }
     when Hash
-      then @headers.map { |header| sanitize_field(row[header]) }
+      then headers.map { |header| sanitize_field(row[header]) }
     else
       row.map { |field| sanitize_field(field) }
     end

--- a/lib/csv-safe.rb
+++ b/lib/csv-safe.rb
@@ -49,13 +49,10 @@ class CSVSafe < CSV
   end
 
   def sanitize_row(row)
-    case row
-    when self.class::Row
-      then row.fields.map { |field| sanitize_field(field) }
-    when Hash
-      then headers.map { |header| sanitize_field(row[header]) }
-    else
-      row.map { |field| sanitize_field(field) }
-    end
+    return row.fields.map { |field| sanitize_field(field) } if row.is_a?(self.class::Row)
+
+    return @headers.map { |header| sanitize_field(row[header]) } if row.is_a?(Hash) && !@headers.nil?
+
+    row.map { |field| sanitize_field(field) }
   end
 end

--- a/spec/csv_safe_spec.rb
+++ b/spec/csv_safe_spec.rb
@@ -144,13 +144,10 @@ RSpec.describe CSVSafe do
 
       context 'when the row is a Hash' do
         before(:all) do
-          CSV_Instance = CSVSafe.new('')
+          CSV_Instance = CSVSafe.new('', headers: %i[Name Age])
         end
         subject { CSV_Instance.send(:sanitize_row, row) }
 
-        before do
-          CSV_Instance.instance_variable_set(:@headers, %i[Name Age])
-        end
         context "when the fields don't require sanitization" do
           let(:row) { { Name: 'Jane', Age: '30' } }
           let(:expected) { %w[Jane 30] }
@@ -168,9 +165,9 @@ RSpec.describe CSVSafe do
           headers = %i[a b c]
           payload = { b: :b, a: :a, c: :c }
 
-          output = CSVSafe.generate(headers: true) { |csv| csv << headers; csv << payload }
+          output = CSVSafe.generate(headers: true) { |csv| csv << headers; csv << payload }.split "\n"
 
-          expect(output).to eq("a,b,c\n\"[:b, :b]\",\"[:a, :a]\",\"[:c, :c]\"\n")
+          expect(output).to eq(["a,b,c", "a,b,c"])
         end
       end
 

--- a/spec/csv_safe_spec.rb
+++ b/spec/csv_safe_spec.rb
@@ -122,12 +122,12 @@ RSpec.describe CSVSafe do
     end
 
     describe '#sanitize_row' do
-      before(:all) do
-        CSV_Instance = CSVSafe.new('')
-      end
-      subject { CSV_Instance.send(:sanitize_row, row) }
-
       context 'when the row is a CSV::Row' do
+        before(:all) do
+          CSV_Instance = CSVSafe.new('')
+        end
+        subject { CSV_Instance.send(:sanitize_row, row) }
+
         context "when the fields don't require sanitization" do
           let(:fields) { %w[Jane 30] }
           let(:row) { CSV::Row.new(%w[Name Age], fields) }
@@ -143,6 +143,11 @@ RSpec.describe CSVSafe do
       end
 
       context 'when the row is a Hash' do
+        before(:all) do
+          CSV_Instance = CSVSafe.new('')
+        end
+        subject { CSV_Instance.send(:sanitize_row, row) }
+
         before do
           CSV_Instance.instance_variable_set(:@headers, %i[Name Age])
         end
@@ -158,9 +163,23 @@ RSpec.describe CSVSafe do
 
           it { should eq expected }
         end
+
+        it "does not crash" do
+          headers = %i[a b c]
+          payload = { b: :b, a: :a, c: :c }
+
+          output = CSVSafe.generate(headers: true) { |csv| csv << headers; csv << payload }
+
+          expect(output).to eq("a,b,c\n\"[:b, :b]\",\"[:a, :a]\",\"[:c, :c]\"\n")
+        end
       end
 
       context 'when the row is an array' do
+        before(:all) do
+          CSV_Instance = CSVSafe.new('')
+        end
+        subject { CSV_Instance.send(:sanitize_row, row) }
+
         context "when the fields don't require sanitization" do
           let(:row) { %w[Jane 30] }
           it { should eq row }


### PR DESCRIPTION
Fix https://github.com/zvory/csv-safe/issues/15

https://ruby-doc.org/stdlib-3.0.0/libdoc/csv/rdoc/CSV.html#method-i-headers rather than the internal variable being targetted.