### PR TITLE
Sanitize fields with leading whitespace before formula characters

### DIFF
--- a/lib/csv-safe.rb
+++ b/lib/csv-safe.rb
@@ -24,8 +24,15 @@ class CSVSafe < CSV
   private_constant :DANGEROUS_LEADING_CHARS
 
   def starts_with_special_character?(str)
-    str.start_with?(*DANGEROUS_LEADING_CHARS) ||
-      str.lstrip.start_with?(*DANGEROUS_LEADING_CHARS)
+    # The first check is load-bearing, not redundant with the second: \r, \t
+    # and \n are both dangerous leading chars AND whitespace that lstrip
+    # removes, so the lstrip check alone would miss a field like "\tfoo".
+    return true if str.start_with?(*DANGEROUS_LEADING_CHARS)
+
+    # lstrip raises ArgumentError on invalid byte sequences; for those, fall
+    # back to the first-char check only (preserves the pre-existing
+    # non-raising behavior for malformed-encoding fields).
+    str.valid_encoding? && str.lstrip.start_with?(*DANGEROUS_LEADING_CHARS)
   end
 
   def prefix(field)

--- a/lib/csv-safe.rb
+++ b/lib/csv-safe.rb
@@ -20,8 +20,12 @@ class CSVSafe < CSV
 
   private
 
+  DANGEROUS_LEADING_CHARS = ["-", "=", "+", "@", "%", "|", "\r", "\t", "\n"].freeze
+  private_constant :DANGEROUS_LEADING_CHARS
+
   def starts_with_special_character?(str)
-    str.start_with?("-", "=", "+", "@", "%", "|", "\r", "\t")
+    str.start_with?(*DANGEROUS_LEADING_CHARS) ||
+      str.lstrip.start_with?(*DANGEROUS_LEADING_CHARS)
   end
 
   def prefix(field)

--- a/spec/csv_safe_spec.rb
+++ b/spec/csv_safe_spec.rb
@@ -84,6 +84,34 @@ RSpec.describe CSVSafe do
       end
     end
 
+    # Regression guard: a leading \t/\r/\n is both a dangerous char and
+    # whitespace. The non-lstrip branch of starts_with_special_character? must
+    # keep prefixing these even though the rest of the field is harmless --
+    # lstrip alone would strip the char and let it through.
+    context 'with a leading whitespace-control char before harmless content' do
+      context 'leading tab' do
+        let(:field) { "\tfoo" }
+        let(:expected) { "'\tfoo" }
+        it { should eq expected }
+      end
+
+      context 'leading carriage return' do
+        let(:field) { "\rfoo" }
+        let(:expected) { "'\rfoo" }
+        it { should eq expected }
+      end
+    end
+
+    context 'with a field containing an invalid byte sequence' do
+      let(:field) { "\xff\xfe plain".dup.force_encoding('UTF-8') }
+      it 'does not raise (lstrip would otherwise blow up)' do
+        expect { subject }.to_not raise_error
+      end
+      it 'passes the field through unchanged' do
+        expect(subject).to eq field
+      end
+    end
+
     context 'with a field that starts with a @' do
       let(:field) { "@=-2+3+cmd|' /C calc'!'E2'" }
       let(:expected) { "'@=-2+3+cmd|' /C calc'!'E2'" }

--- a/spec/csv_safe_spec.rb
+++ b/spec/csv_safe_spec.rb
@@ -53,6 +53,37 @@ RSpec.describe CSVSafe do
       it { should eq expected }
     end
 
+    context 'with a field that starts with a \n' do
+      let(:field) { "\n2+3+cmd|' /C calc'!'E2'" }
+      let(:expected) { "'\n2+3+cmd|' /C calc'!'E2'" }
+      it { should eq expected }
+    end
+
+    context 'with a field that has leading whitespace before a formula character' do
+      context 'a single leading space' do
+        let(:field) { " =cmd|' /C calc'!'E2'" }
+        let(:expected) { "' =cmd|' /C calc'!'E2'" }
+        it { should eq expected }
+      end
+
+      context 'multiple leading spaces' do
+        let(:field) { "   =cmd|' /C calc'!'E2'" }
+        let(:expected) { "'   =cmd|' /C calc'!'E2'" }
+        it { should eq expected }
+      end
+
+      context 'leading space then @' do
+        let(:field) { " @SUM(1,2)" }
+        let(:expected) { "' @SUM(1,2)" }
+        it { should eq expected }
+      end
+
+      context 'leading whitespace before harmless content stays unchanged' do
+        let(:field) { "  hello" }
+        it { should eq "  hello" }
+      end
+    end
+
     context 'with a field that starts with a @' do
       let(:field) { "@=-2+3+cmd|' /C calc'!'E2'" }
       let(:expected) { "'@=-2+3+cmd|' /C calc'!'E2'" }


### PR DESCRIPTION
## Summary

Fixes a CSV-injection bypass where a field like `" =cmd|..."` (a leading
space, then a formula character) passed through the sanitizer untouched.
The check used `String#start_with?` against the formula characters
directly, so anything that masked the formula character with leading
whitespace was missed. Some spreadsheet importers (notably Google
Sheets, LibreOffice, and various CSV→XLSX converters) strip leading
whitespace before evaluating cells, so the formula would then fire on
import.

The fix re-runs the special-character check after `lstrip`, so leading
whitespace no longer hides a formula. Also adds `\n` to the unsafe
leading-character set for parity with `\r` and `\t`.

Existing behavior is preserved: any field that already started with a
recognized special character (`- = + @ % | \r \t`) is still prefixed —
the new check is purely additive.

## Test plan

- [x] `bundle exec rspec` — 44 examples, 0 failures, 100% line coverage
- [x] New cases cover: single leading space + `=`, multiple leading
      spaces + `=`, leading space + `@`, leading `\n` + content,
      leading whitespace before harmless content (must NOT be prefixed)
- [ ] Manual sanity check: open a generated CSV with a `" =1+1"`
      payload in Google Sheets / LibreOffice / Excel and confirm it
      renders as text after this fix

## Out of scope

- Other plausible-but-unverified bypasses (U+00A0 non-breaking space,
  U+FEFF BOM, fullwidth `＝`). I'd want evidence of an actual importer
  evaluating these before broadening the strip set.
- The encode/decode round-trip asymmetry (the read-side converter also
  sanitizes rather than unsanitizing). That's a correctness issue, not
  a security one — separate PR.